### PR TITLE
Added findByTextContaining on Licenses

### DIFF
--- a/src/main/java/cat/udl/eps/entsoftarch/repository/ClosedLicenseRepository.java
+++ b/src/main/java/cat/udl/eps/entsoftarch/repository/ClosedLicenseRepository.java
@@ -14,4 +14,5 @@ import java.util.List;
 @RepositoryRestResource
 public interface ClosedLicenseRepository extends PagingAndSortingRepository <ClosedLicense, Long> {
     List <ClosedLicense> findByText(@Param("text") String text);
+    List <ClosedLicense> findByTextContaining(@Param("text") String text);
 }

--- a/src/main/java/cat/udl/eps/entsoftarch/repository/OpenLicenseRepository.java
+++ b/src/main/java/cat/udl/eps/entsoftarch/repository/OpenLicenseRepository.java
@@ -14,4 +14,5 @@ import java.util.List;
 @RepositoryRestResource
 public interface OpenLicenseRepository extends PagingAndSortingRepository <OpenLicense, Long> {
     List <OpenLicense> findByText(@Param("text") String text);
+    List <OpenLicense> findByTextContaining(@Param("text") String text);
 }


### PR DESCRIPTION
Added a findByTextContaining on both open and closed licenses in order to be able to search for licenses on the front end without having to write the full text of the license.